### PR TITLE
Require Claim NFT and Signature to use form

### DIFF
--- a/frontend/src/components/ReceiveBeer.tsx
+++ b/frontend/src/components/ReceiveBeer.tsx
@@ -1,8 +1,10 @@
 import { VStack, Text, Container, Center, Box } from "@chakra-ui/react";
 import { PopupButton } from "@typeform/embed-react";
 import styled from "@emotion/styled";
+import { useRef, useEffect } from "react";
+import { BigNumber } from "alchemy-sdk";
 
-const StyledPopupButton = styled(PopupButton)`
+const StyledButton = styled.button`
   font-family: texturina;
   color: white;
   background-color: #ff3864;
@@ -14,9 +16,31 @@ const StyledPopupButton = styled(PopupButton)`
   :hover {
     opacity: 0.85;
   }
+  :disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
 `;
 
-const ReceiveBeer = () => {
+const StyledPopupButton = styled(PopupButton)`
+  visibility: hidden;
+`;
+
+const ReceiveBeer = ({
+  canOpenForm,
+  signMessage,
+  balance,
+}: {
+  canOpenForm: boolean;
+  signMessage: () => void;
+  balance: BigNumber | undefined;
+}) => {
+  const ref = useRef();
+  const openPopup = () => ref.current?.open();
+  useEffect(() => {
+    canOpenForm && openPopup();
+  }, [canOpenForm]);
+
   return (
     <Box py={20} backgroundColor="black">
       <Container>
@@ -38,9 +62,15 @@ const ReceiveBeer = () => {
           hand
         </Text>
         <Center>
-          <StyledPopupButton id="sOwDR7pF" className="my-button">
-            Beer Me Form
-          </StyledPopupButton>
+          <StyledButton
+            id="sOwDR7pF"
+            className="my-button"
+            disabled={!balance?.gt(0)}
+            onClick={() => signMessage()}
+          >
+            {balance?.gt(0) ? "Beer Me Form" : "Claim NFT Required"}
+          </StyledButton>
+          <StyledPopupButton id="sOwDR7pF" ref={ref} />
         </Center>
       </Container>
     </Box>


### PR DESCRIPTION
This PR gates the claim typeform to only allow for accounts that own a claim NFT. It uses wagmi `useSignMessage` hook and `useBalance` hook to ensure the account claiming is valid.

Button Disabled
![image](https://user-images.githubusercontent.com/36084652/227036266-855a4ac8-4052-4a31-8e87-7e00d7b8a251.png)

Sign Message
<img width="1240" alt="Screenshot 2023-03-22 at 1 58 21 PM" src="https://user-images.githubusercontent.com/36084652/227036496-c6309a2e-e6fb-4f75-b3f2-231622a0fecb.png">
